### PR TITLE
FIX: Replace logic not worikng right for "android" platfrom

### DIFF
--- a/lib/ImportReplacePlugin.js
+++ b/lib/ImportReplacePlugin.js
@@ -62,8 +62,7 @@ exports.ImportReplacePlugin = (function () {
         var platformSuffix = "." + this.platform;
         this.debug('adding platform suffix: ', platformSuffix);
         var additionLength = platformSuffix.length;
-        var escapeAndEnding = 2; // usually "\";" or "\';"
-        var remainingStartIndex = result.index + (result.match.length - 1) + (platformSuffix.length - 1) - escapeAndEnding;
+        var remainingStartIndex = result.index + result.match.length;
 
         sourceFile.text =
           sourceFileText.substring(0, result.index) +


### PR DESCRIPTION
The replace logic was "eating" a few more symbols when the platform is `android`.

